### PR TITLE
Use Pry::ColorPrinter if available

### DIFF
--- a/haml_parser.gemspec
+++ b/haml_parser.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.3.0"
   spec.add_development_dependency "simplecov"

--- a/lib/haml_parser/cli.rb
+++ b/lib/haml_parser/cli.rb
@@ -7,8 +7,10 @@ module HamlParser
     end
 
     def start(argv)
+      formatter = 'pretty'
       print_version = false
       OptionParser.new.tap do |parser|
+        parser.on('-f FORMAT', '--format FORMAT', 'Select formatter') { |v| formatter = v }
         parser.on('-v', '--version', 'Print version') { print_version = true }
       end.parse!(argv)
       if print_version
@@ -16,15 +18,29 @@ module HamlParser
         return
       end
 
-      require 'pp'
       require 'haml_parser/parser'
       argv.each do |file|
-        pp parse_file(file)
+        format(parse_file(file), formatter)
       end
     end
 
     def parse_file(file)
       HamlParser::Parser.new(filename: file).call(File.read(file))
+    end
+
+    private
+
+    def format(obj, formatter)
+      case formatter
+      when 'pretty'
+        require 'pp'
+        pp obj
+      when 'pry'
+        require 'pry'
+        Pry::ColorPrinter.pp obj
+      else
+        abort "Unknown formatter: #{formatter}"
+      end
     end
   end
 end


### PR DESCRIPTION
Because AST is complex and hard to read, I want to colorize CLI output.
With this patch, haml\_parser will colorize AST if pry is installed.